### PR TITLE
enable ssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY --chown=aryn:aryn ./config ./config
 COPY --chown=aryn:aryn ./rps_docker_entrypoint.sh ./
 RUN make -f ../Makefile server_build
 RUN chmod +x rps_docker_entrypoint.sh
+RUN chown aryn:aryn ./
 
 EXPOSE $RPS_PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,11 @@ COPY --from=rps_build --chown=aryn:aryn /aryn/rps/proto_remote_processor ./proto
 COPY --chown=aryn:aryn ./lib ./lib/
 COPY --chown=aryn:aryn ./service ./service
 COPY --chown=aryn:aryn ./README.md ./README.md
-COPY --chown=aryn:aryn ./configs ./configs
+COPY --chown=aryn:aryn ./config ./config
+COPY --chown=aryn:aryn ./rps_docker_entrypoint.sh ./
 RUN make -f ../Makefile server_build
+RUN chmod +x rps_docker_entrypoint.sh
 
 EXPOSE $RPS_PORT
 
-CMD ["poetry", "run", "server", "config/pipelines.yml"]
+CMD ./rps_docker_entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY --chown=aryn:aryn ./config ./config
 COPY --chown=aryn:aryn ./rps_docker_entrypoint.sh ./
 RUN make -f ../Makefile server_build
 RUN chmod +x rps_docker_entrypoint.sh
-RUN chown aryn:aryn ./
+RUN chown -R aryn:aryn .
 
 EXPOSE $RPS_PORT
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,21 +1,30 @@
-version: '3'
+version: "3"
 services:
   opensearch:
     image: rps-os
     container_name: opensearch
     environment:
-      - discovery.type=single-node
+      - OPENAI_API_KEY
+      # To help with debugging issues with opensearch starting.
+      - DEBUG
+      - NOEXIT
     ports:
       - 9200:9200
       - 9600:9600
     networks:
       - os-net
+    volumes:
+      - rpsos:/usr/share/opensearch/data
   rps:
     image: rps
     container_name: rps
-    ports: 
+    ports:
       - 2796:2796
     networks:
       - os-net
+    environment:
+      - SSL_HOSTNAME=rps
 networks:
   os-net:
+volumes:
+  rpsos:

--- a/rps_docker_entrypoint.sh
+++ b/rps_docker_entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+die() {
+    echo "ERROR:" "$@" 1>&2
+    if [[ ${NOEXIT} -gt 0 ]]; then
+        echo "Not dying due to NOEXIT.  Feel free to poke around container."
+        sleep inf
+    fi
+    exit 1
+}
+
+create_certificates() {
+    local HOST="${SSL_HOSTNAME:-localhost}"
+    local DAYS=10000
+    local LOG="config/openssl.err"
+    truncate -s 0 "${LOG}"
+
+    # 1. Make fake certificate authority (CA) certificate.  OpenSearch
+    # requires a root certificate to be specified.
+    if [[ (! -f config/cakey.pem) || (! -f config/cacert.pem) ]]; then
+        openssl req -batch -x509 -newkey rsa:4096 -days "${DAYS}" \
+        -subj "/C=US/ST=California/O=Aryn.ai/CN=Fake CA" \
+        -extensions v3_ca -noenc -keyout config/cakey.pem -out config/cacert.pem \
+        2>> "${LOG}" || die "Failed to create CA certificate"
+        echo "Created CA certificate"
+    fi
+
+    # 2a. Create certificate signing request (CSR) for the node certificate.
+    if [[ (! -f config/rps-key.pem) || (! -f config/rps-cert.pem) ]]; then
+        openssl req -batch -newkey rsa:4096 \
+        -subj "/C=US/ST=California/O=Aryn.ai/CN=${HOST}" \
+        -extensions v3_req -addext "basicConstraints=critical,CA:FALSE" \
+        -addext "subjectAltName=DNS:${HOST}" \
+        -noenc -keyout config/rps-key.pem -out config/rps-req.pem \
+        2>> "${LOG}" || die "Failed to create RPS CSR"
+
+        # 2b. Use the fake CA to sign the node CSR, yielding a certificate.
+        openssl x509 -req -CA config/cacert.pem -CAkey config/cakey.pem \
+        -copy_extensions copy -days "${DAYS}" \
+        -in config/rps-req.pem -out config/rps-cert.pem \
+        2>> "${LOG}" || die "Failed to create RPS certificate"
+        echo "Created RPS certificate"
+    fi
+
+    rm -f config/rps-req.pem
+    for X in cakey.pem cacert.pem rps-key.pem rps-cert.pem; do
+        chmod 600 "config/${X}"
+    done
+}
+
+main() {
+    export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+    create_certificates
+    poetry run server config/pipelines.yml --keyfile config/rps-key.pem --certfile config/rps-cert.pem
+}
+
+main

--- a/rps_docker_entrypoint.sh
+++ b/rps_docker_entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+main() {
+    create_certificates
+    poetry run server config/pipelines.yml --keyfile config/rps-key.pem --certfile config/rps-cert.pem
+}
+
 die() {
     echo "ERROR:" "$@" 1>&2
     if [[ ${NOEXIT} -gt 0 ]]; then
@@ -15,43 +20,18 @@ create_certificates() {
     local LOG="config/openssl.err"
     truncate -s 0 "${LOG}"
 
-    # 1. Make fake certificate authority (CA) certificate.  OpenSearch
-    # requires a root certificate to be specified.
-    if [[ (! -f config/cakey.pem) || (! -f config/cacert.pem) ]]; then
-        openssl req -batch -x509 -newkey rsa:4096 -days "${DAYS}" \
-        -subj "/C=US/ST=California/O=Aryn.ai/CN=Fake CA" \
-        -extensions v3_ca -noenc -keyout config/cakey.pem -out config/cacert.pem \
-        2>> "${LOG}" || die "Failed to create CA certificate"
-        echo "Created CA certificate"
-    fi
-
-    # 2a. Create certificate signing request (CSR) for the node certificate.
+    # Create RPS certificate.
     if [[ (! -f config/rps-key.pem) || (! -f config/rps-cert.pem) ]]; then
-        openssl req -batch -newkey rsa:4096 \
+        openssl req -batch -x509 -newkey rsa:4096 -days "${DAYS}" \
         -subj "/C=US/ST=California/O=Aryn.ai/CN=${HOST}" \
-        -extensions v3_req -addext "basicConstraints=critical,CA:FALSE" \
-        -addext "subjectAltName=DNS:${HOST}" \
-        -noenc -keyout config/rps-key.pem -out config/rps-req.pem \
-        2>> "${LOG}" || die "Failed to create RPS CSR"
-
-        # 2b. Use the fake CA to sign the node CSR, yielding a certificate.
-        openssl x509 -req -CA config/cacert.pem -CAkey config/cakey.pem \
-        -copy_extensions copy -days "${DAYS}" \
-        -in config/rps-req.pem -out config/rps-cert.pem \
-        2>> "${LOG}" || die "Failed to create RPS certificate"
+        -extensions v3_req -addext "subjectAltName=DNS:${HOST}" \
+        -noenc -keyout "config/rps-key.pem" -out "config/rps-cert.pem" 2> /dev/null
         echo "Created RPS certificate"
     fi
 
-    rm -f config/rps-req.pem
-    for X in cakey.pem cacert.pem rps-key.pem rps-cert.pem; do
+    for X in rps-key.pem rps-cert.pem; do
         chmod 600 "config/${X}"
     done
-}
-
-main() {
-    export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
-    create_certificates
-    poetry run server config/pipelines.yml --keyfile config/rps-key.pem --certfile config/rps-cert.pem
 }
 
 main

--- a/service/cli.py
+++ b/service/cli.py
@@ -14,11 +14,12 @@ def read_cfg(config):
     service = RemoteProcessorService(config)
     print(service)
     print(service._pipelines)
-    print(service._pipelines['debug']._processors)
 
 @click.command()
 @click.argument('config', type=click.Path(exists=True))
-def serve(config):
+@click.option('--certfile', type=click.Path(exists=True), default=None)
+@click.option('--keyfile', type=click.Path(exists=True), default=None)
+def serve(config, certfile, keyfile):
     """
     Start the server on port 2796 with the configuration provided
 
@@ -26,5 +27,10 @@ def serve(config):
         config (filepath): A yaml file that describes all the search processors to run in the RPS
     """
     service = RemoteProcessorService(config)
-    server = service.start()
-    server.wait_for_termination()
+    if certfile is None or keyfile is None:
+        assert keyfile == certfile, "You must either specify both certfile and keyfile or specify neither"
+        server = service.start()
+        server.wait_for_termination()
+    else:
+        server = service.start_secure(certfile, keyfile)
+        server.wait_for_termination()

--- a/service/cli.py
+++ b/service/cli.py
@@ -29,8 +29,5 @@ def serve(config, certfile, keyfile):
     service = RemoteProcessorService(config)
     if certfile is None or keyfile is None:
         assert keyfile == certfile, "You must either specify both certfile and keyfile or specify neither"
-        server = service.start()
-        server.wait_for_termination()
-    else:
-        server = service.start(certfile, keyfile)
-        server.wait_for_termination()
+    server = service.start(certfile, keyfile)
+    server.wait_for_termination()

--- a/service/cli.py
+++ b/service/cli.py
@@ -32,5 +32,5 @@ def serve(config, certfile, keyfile):
         server = service.start()
         server.wait_for_termination()
     else:
-        server = service.start_secure(certfile, keyfile)
+        server = service.start(certfile, keyfile)
         server.wait_for_termination()

--- a/service/remote_processor_service.py
+++ b/service/remote_processor_service.py
@@ -98,15 +98,11 @@ class RemoteProcessorService(RemoteProcessorServiceServicer):
             Server: a grpc server object
         """
         logging.info(PAPRIKA_ASCII_ART)
-        secure_mode = False
-        if certfile is not None and keyfile is not None:
-            secure_mode = True
-            logging.info("Starting service in secure mode")
-        else:
-            logging.info("Starting service in insecure mode")
+        secure_mode = bool(certfile and keyfile)
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=TP_MAX_WORKERS))
         add_RemoteProcessorServiceServicer_to_server(self, server)
         if secure_mode:
+            logging.info("Starting service in secure mode")
             with open(keyfile, 'rb') as f:
                 private_key = f.read()
             with open(certfile, 'rb') as f:
@@ -118,6 +114,7 @@ class RemoteProcessorService(RemoteProcessorServiceServicer):
             )
             server.add_secure_port("[::]:2796", channel_credentials)
         else:
+            logging.info("Starting service in insecure mode")
             server.add_insecure_port("[::]:2796")
         server.start()
         logging.info("RPS started on port 2796")

--- a/service/remote_processor_service.py
+++ b/service/remote_processor_service.py
@@ -14,10 +14,10 @@ from proto_remote_processor.response_processor_service_pb2 import ProcessRespons
 TP_MAX_WORKERS = 10
 
 PAPRIKA_ASCII_ART = '''
- ______   ______     ______   ______     __     __  __     ______    
-/\\  == \\ /\\  __ \\   /\\  == \\ /\\  == \\   /\\ \\   /\\ \\/ /    /\\  __ \\   
-\\ \\  _-/ \\ \\  __ \\  \\ \\  _-/ \\ \\  __<   \\ \\ \\  \\ \\  _"-.  \\ \\  __ \\  
- \\ \\_\\    \\ \\_\\ \\_\\  \\ \\_\\    \\ \\_\\ \\_\\  \\ \\_\\  \\ \\_\\ \\_\\  \\ \\_\\ \\_\\ 
+ ______   ______     ______   ______     __     __  __     ______
+/\\  == \\ /\\  __ \\   /\\  == \\ /\\  == \\   /\\ \\   /\\ \\/ /    /\\  __ \\
+\\ \\  _-/ \\ \\  __ \\  \\ \\  _-/ \\ \\  __<   \\ \\ \\  \\ \\  _"-.  \\ \\  __ \\
+ \\ \\_\\    \\ \\_\\ \\_\\  \\ \\_\\    \\ \\_\\ \\_\\  \\ \\_\\  \\ \\_\\ \\_\\  \\ \\_\\ \\_\\
   \\/_/     \\/_/\\/_/   \\/_/     \\/_/ /_/   \\/_/   \\/_/\\/_/   \\/_/\\/_/
 '''
 
@@ -66,7 +66,7 @@ class RemoteProcessorService(RemoteProcessorServiceServicer):
             pipeline = Pipeline(name, cfg[name], self._pr)
             pipelines[name] = pipeline
         return pipelines
-    
+
     def ProcessResponse(self, request: ProcessResponseRequest, context):
         """Process a response. Entrypoint for ProcessResponse API
 
@@ -90,7 +90,7 @@ class RemoteProcessorService(RemoteProcessorServiceServicer):
             context.set_code(grpc.StatusCode.NOT_FOUND)
             context.set_details(f'Processor {processor_name} does not exist!')
             raise KeyError(f"Processor {processor_name} does not exist! Check your config file {self._config_file}")
-        
+
     def start(self):
         """Start the server on port 2796 (ARYN on a keypad)
 
@@ -98,11 +98,34 @@ class RemoteProcessorService(RemoteProcessorServiceServicer):
             Server: a grpc server object
         """
         logging.info(PAPRIKA_ASCII_ART)
+        logging.info("Starting service in insecure mode")
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=TP_MAX_WORKERS))
         add_RemoteProcessorServiceServicer_to_server(self, server)
         server.add_insecure_port("[::]:2796")
         server.start()
         logging.info("RPS started on port 2796")
         return server
-        
-    
+
+    def start_secure(self, certfile, keyfile):
+        """Start the server on port 2796 (ARYN on a keyboard) with encryption
+
+        Returns:
+            Server: a grpc server object
+        """
+        logging.info(PAPRIKA_ASCII_ART)
+        logging.info("Starting service in secure mode")
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=TP_MAX_WORKERS))
+        add_RemoteProcessorServiceServicer_to_server(self, server)
+        with open(keyfile, 'rb') as f:
+            private_key = f.read()
+        with open(certfile, 'rb') as f:
+            cert_chain = f.read()
+        channel_credentials = grpc.ssl_server_credentials(
+            private_key_certificate_chain_pairs=[(private_key, cert_chain)],
+            root_certificates=None,
+            require_client_auth=False
+        )
+        server.add_secure_port("[::]:2796", channel_credentials)
+        server.start()
+        logging.info('RPS started on port 2796')
+        return server


### PR DESCRIPTION
- run RPS as SSL with `poetry run server config/pipelines.yml --certfile path/to/certifle.pem --keyfile path/to/keyfile.pem`
- docker container runs ssl by default
- docker compose runs ssl by default and sets host name appropriatley so that opensearch can talk to it