### PR TITLE
Update Docker files to work better with our automation scripts and im…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,34 @@
-
-
-ARG POETRY_NO_INTERACTION=1
-ARG POETRY_VIRTUALENVS_IN_PROJECT=1
-ARG POETRY_VIRTUALENVS_CREATE=1 \
-ARG POETRY_CACHE_DIR=/tmp/poetry_cache
-ARG RPS_PORT=2796
+# Repo name: arynai/remote-processor-service
 
 ##########
 # Common: resolve dependencies
 FROM python:3.11 AS rps_common
+
+ARG RPS_PORT=2796
+ARG POETRY_NO_INTERACTION=1
+ARG POETRY_VIRTUALENVS_IN_PROJECT=1
+ARG POETRY_VIRTUALENVS_CREATE=1
+ARG POETRY_CACHE_DIR=/tmp/poetry_cache
 
 # Is there some way to keep this common layer common across all our services?
 # E.g. maybe we can have an image called 'aryn_service_base' or something
 # - setup aryn user and directory
 # - install commonly used software (poetry, maybe protoc)
 # And then we can just layer services on top?
-WORKDIR /aryn
+
+WORKDIR /aryn/
 COPY ./Makefile ./
 RUN make aryn_user
-RUN make install_poetry
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    make install_poetry
 
 USER aryn
 WORKDIR /aryn/rps/
 COPY --chown=aryn:aryn ./poetry.lock ./pyproject.toml ./
-RUN make -f ../Makefile common_build
+RUN --mount=type=cache,id=cache_poetry_1000,target=/tmp/poetry_cache,uid=1000,gid=1000,sharing=locked \
+    make -f ../Makefile common_build
 
 ##########
 # Build: build package, compile protobufs
@@ -31,7 +36,8 @@ FROM rps_common AS rps_build
 
 # Build the proto files into python
 COPY --chown=aryn:aryn ./protocols ./protocols
-RUN make -f ../Makefile build_proto
+RUN --mount=type=cache,id=cache_poetry_1000,target=/tmp/poetry_cache,uid=1000,gid=1000,sharing=locked \
+    make -f ../Makefile docker_build_proto
 
 ##########
 # Run: run the server
@@ -45,7 +51,8 @@ COPY --chown=aryn:aryn ./config ./config
 COPY --chown=aryn:aryn ./rps_docker_entrypoint.sh ./
 RUN make -f ../Makefile server_build
 RUN chmod +x rps_docker_entrypoint.sh
-RUN chown -R aryn:aryn .
+RUN make -f ../Makefile user_check
+# chown -R aryn:aryn .
 
 EXPOSE $RPS_PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ COPY --chown=aryn:aryn ./rps_docker_entrypoint.sh ./
 RUN make -f ../Makefile server_build
 RUN chmod +x rps_docker_entrypoint.sh
 RUN make -f ../Makefile user_check
-# chown -R aryn:aryn .
 
 EXPOSE $RPS_PORT
 

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,12 @@
 help:
-	@echo "install_poetry: installs poetry on ubuntu"
+	@echo "install_rps: installs dependencies, builds proto, then installs the package"
 	@echo "clean: clean up grpc-generated code (by deletion)"
 	@echo "build_proto: generate code from the .proto files in protocols/proto-remote-processor"
-	@echo "install_rps: installs dependencies, builds proto, then installs the package"
-	@echo "common_build: install main dependencies"
-	@echo "server_build: install the package, but not the dependencies"
-
-install_poetry:
-	apt update
-	DEBIAN_FRONTEND=noninteractive apt -y install --no-install-recommends python3-poetry gcc python3-dev
-	apt clean
-	-rm -rf /var/lib/apt/lists/*
-	poetry config virtualenvs.path /rps/poetry_venv
 
 clean:
 	-rm -rd proto_remote_processor
 
 build_proto:
-	poetry install --no-root --only build
 	poetry run python -m grpc_tools.protoc -I protocols/ --python_out=. --pyi_out=. --grpc_python_out=. protocols/proto-remote-processor/*.proto
 
 install_rps:
@@ -25,13 +14,38 @@ install_rps:
 	make build_proto
 	poetry install --only-root
 
-common_build:
-	poetry install --no-root --only main
-
-server_build:
-	poetry install --only-root
+### Docker steps sorted in the same order as the Dockerfile
+### Not for general use so undocumented
 
 aryn_user:
 	groupadd --gid 1000 aryn
 	useradd --uid 1000 --gid 1000 --home-dir /aryn --password=y --no-create-home aryn
 	chown -R aryn:aryn /aryn
+
+install_poetry:
+	touch /var/lib/apt/.cache_var_lib_apt # make it possible to find the cache directory for buildx builds
+	touch /var/cache/apt/.cache_var_cache_apt
+	apt update
+	DEBIAN_FRONTEND=noninteractive apt -y install --no-install-recommends python3-poetry gcc python3-dev
+
+common_build:
+	test "$(POETRY_CACHE_DIR)" = /tmp/poetry_cache # catch a bug where putting ARG too early in Dockerfile doesn't get the env var
+	touch /tmp/poetry_cache/.poetry_cache_dir
+	poetry install --no-root --only main
+	poetry env info
+
+docker_build_proto:
+	test "$(POETRY_CACHE_DIR)" = /tmp/poetry_cache
+	poetry install --no-root --only build
+	make -f ../Makefile build_proto
+
+server_build:
+	poetry install --only-root
+
+user_check:
+	FILES=$$(find /aryn -print | wc -l); \
+	ARYN_FILES=$$(find /aryn -user aryn -print | wc -l); \
+	echo "Found $${ARYN_FILES}/$${FILES} owned by aryn"; \
+	find /aryn ! -user aryn -print; \
+	test $${FILES} -ge 1000 && \
+	test $${ARYN_FILES} -eq $${FILES}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# Repo name: arynai/opensearch-rps
 FROM gradle:jdk17 AS assemble_plugin
 
 WORKDIR /build


### PR DESCRIPTION
…prove caching.

* Move the Args under the from, otherwise they don't do anything
* Enable caching for apt & poetry downloads (>10x speedup)
* Remove chowning of files and just check that the files are properly owned
* Split Makefile into "local build" and "docker build" targets. Tweak the one shared one.
* Resort Makefile target order to match Dockerfile.
* Add checks in the Makefile for various errors and to be able to find the cache files.
* Put a hacky repo name in the opensearch-rps Dockerfile.